### PR TITLE
fix vercel deploy

### DIFF
--- a/.vercel.json
+++ b/.vercel.json
@@ -1,0 +1,3 @@
+{
+  "buildCommand": "corepack enable && corepack prepare pnpm@10.10.0 --activate && pnpm install && pnpm build"
+}


### PR DESCRIPTION
あなたが開発環境（Macとか）で
→ nvm use 22.15.0 とかしてNode.jsとpnpmのバージョンをちゃんと合わせてるのは正しい。

でも、Vercelのビルドサーバーには
Vercel
→ nvm は入ってない（Nodeのバージョン管理ツールは使えない）

だから、Vercel側では、

.nvmrc とか .node-version があっても 無視される

Vercelの設定 or engines.node とかで直接指定する必要がある

さらにpnpmのバージョンもビルドコマンドで指定する必要がある

corepack enable | corepack（Node.js公式のパッケージマネージャー管理機能）を有効化
corepack prepare pnpm@10.0.0 --activate | pnpmのバージョン10.0.0をダウンロードして有効化（ビルド環境内だけ）
pnpm install | 依存関係をインストール（ここでpnpm10が使われる）
pnpm build | ビルドを実行（これもpnpm10環境下）

