### PR TITLE
cicdでvercelデプロイ,lint,migrationを制御すべき

### DIFF
--- a/.github/workflows/prod-migration.yml
+++ b/.github/workflows/prod-migration.yml
@@ -1,12 +1,17 @@
 name: Release (Production)
 
 on:
-  push:
+  pull_request:
     branches:
       - main
+    paths:
+      - "supabase/migrations/**"
+    types:
+      - closed
 
 jobs:
   migrate:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     env:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}


### PR DESCRIPTION
cicdの修正
旧版は mainに直pushでは知ってしまっていたので、条件を狭めた。